### PR TITLE
version 1.5.1 - jQuery 1.12.4 fix

### DIFF
--- a/modules/mtl-tile-list/mtl-tile-list.js
+++ b/modules/mtl-tile-list/mtl-tile-list.js
@@ -37,7 +37,7 @@ var paginationClicked = false;
 jQuery(document).ready(function($){
 	if(currentHash.replace('#!','')!=currentHash ) loadNewTiles(tilePageUrl+currentHash.replace('#!',''));
 
-	$('.mtl-paginate-links a').live('click', function(e)  {
+	$('.mtl-paginate-links a').on('click', function(e)  {
 		e.preventDefault();
 		window.location.hash = '!'+$(this).attr('href').replace(tilePageUrl,'');
 		

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://www.stadtkreation.de/
 Author: Johannes Bouchain
 Author URI: http://www.stadtkreation.de/
 Description: "My Transit Lines" is a Wordpress theme developed for urban and regional public transit platforms. Follow the theme link to find out more. New additions since version 1.0: Rating tool added, minor bugs fixed, GeoJSON download added.
-Version: 1.5
+Version: 1.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: my-transit-lines


### PR DESCRIPTION
jQuery 1.12.4 fix in modules/mtl-tile-list/mtl-tile-list.js - jQuery .live() function deprecated since jQuery 1.9